### PR TITLE
feat: switch back to geopackage as storage format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,7 +38,7 @@ async function main(req: LambdaRequest): Promise<void> {
     datasetCount++;
     req.log.info({ datasetId: dataset.id, updatedAt: dataset.info.published_at }, 'Dataset:Fetch');
     const [latestVersion] = await dataset.versions;
-    const exportName = `${dataset.id}-${latestVersion.id}-csv`;
+    const exportName = `${dataset.id}-${latestVersion.id}-gpkg`;
 
     const datasetExports = exports.filter((f) => f.name.startsWith(`lds-${exportName}`));
 

--- a/src/kx.ts
+++ b/src/kx.ts
@@ -121,7 +121,7 @@ export class KxApi {
       JSON.stringify({
         crs,
         name: exportName,
-        formats: { vector: 'text/csv' },
+        formats: { vector: 'application/x-ogc-gpkg' },
         items: [{ item: `${this.endpoint}/layers/${datasetId}/` }],
       }),
     );

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -9,8 +9,8 @@ import { KxDataset } from './kx.dataset.js';
 import { KxDatasetExport } from './kx.js';
 import { Stac } from './stac.js';
 
-/** Assume CSV */
-const PackageExtension = '.csv';
+/** Assume geopackage */
+const PackageExtension = '.gpkg';
 
 export async function getOrCreate<T extends Record<string, unknown>>(
   uri: string,
@@ -83,7 +83,10 @@ export async function ingest(req: LambdaRequest, dataset: KxDataset, ex: KxDatas
         fileSize += d.length;
         hash.update(d);
       });
-      fsa.write(targetFileUri, gz, { contentType: 'text/csv', contentEncoding: 'gzip' }).then(resolve).catch(reject);
+      fsa
+        .write(targetFileUri, gz, { contentType: 'application/geopackage+vnd.sqlite3', contentEncoding: 'gzip' })
+        .then(resolve)
+        .catch(reject);
     });
     zip.on('error', reject);
   });
@@ -94,7 +97,7 @@ export async function ingest(req: LambdaRequest, dataset: KxDataset, ex: KxDatas
     href: `./${targetFileName}`,
     title: 'Export',
     roles: ['data'],
-    type: 'text/csv',
+    type: 'application/geopackage+vnd.sqlite3',
     encoding: 'gzip',
     datetime: dataset.info.published_at,
     'file:checksum': checksum,


### PR DESCRIPTION
This reverts commit 0b9ce94453bf2dbd62a74562448d13cca0c943e3.

CSV was having issues with numbers vs strings, multi polygons and a few other minor annoyances. 