### PR TITLE
feat: cache KX requests with $KX_USE_CACHE

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ async function main(req: LambdaRequest): Promise<void> {
   const exportIds: number[] = [];
   const ingestIds: number[] = [];
   let datasetCount = 0;
+  let exportSkipped = 0;
 
   const seen = new Set<number>();
   for (const dataset of datasets) {
@@ -71,6 +72,7 @@ async function main(req: LambdaRequest): Promise<void> {
         { datasetId: dataset.id, version: latestVersion.id, exports: exportsInProgress },
         'Export:Skip - Too many in progress',
       );
+      exportSkipped++;
       continue;
     }
     const version = await dataset.getLatestVersion();
@@ -83,6 +85,7 @@ async function main(req: LambdaRequest): Promise<void> {
   if (exportIds.length > 0) req.set('exports', exportIds);
   if (ingestIds.length > 0) req.set('ingests', ingestIds);
   req.set('exportCount', exportIds.length);
+  req.set('exportSkippedCount', exportSkipped);
 
   req.set('datasetCount', datasetCount);
 }

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -26,6 +26,16 @@ export async function getOrCreate<T extends Record<string, unknown>>(
   return fsa.readJson<T>(uri);
 }
 
+let _fileList: string[] | undefined;
+/** List all STAC files in a bucket (assuming anything ending in.json is STAC) */
+export async function listStacFiles(): Promise<string[]> {
+  if (_fileList == null) {
+    const fileList = await fsa.toArray(fsa.list(CachePrefix));
+    _fileList = fileList.filter((f) => f.endsWith('.json'));
+  }
+  return _fileList;
+}
+
 /** Ingest the export into our cache */
 export async function ingest(req: LambdaRequest, dataset: KxDataset, ex: KxDatasetExport): Promise<boolean> {
   const datasetUri = fsa.join(CachePrefix, String(dataset.id));


### PR DESCRIPTION
- feat: add $KX_USE_CACHE to cache requests to kx
- feat: track how many exports are skipped
- feat: list entire cache bucket to save time on indvidual fetch requests
