### PR TITLE
feat(config): add nz-slipway-centerlines to the layer list BM-1201

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -176,6 +176,7 @@ const Monitor = [
   { id: 50348, name: '50348-nz-ski-lift-centrelines-topo-150k' },
   { id: 50349, name: '50349-nz-ski-tow-centrelines-topo-150k' },
   { id: 50350, name: '50350-nz-slip-edges-topo-150k' },
+  { id: 50351, name: '50351-nz-slipway-centrelines-topo-150k' },
   { id: 50353, name: '50353-nz-soakhole-points-topo-150k' },
   { id: 50355, name: '50355-nz-sportsfield-polygons-topo-150k' },
   { id: 50356, name: '50356-nz-spring-points-topo-150k' },


### PR DESCRIPTION
#### Motivation

The [topographic] stylesheet contains style entries for [slipway] centerlines [[1]], [[2]].

However, the `lds-cache` does not import any [slipway] datasets.

#### Modification

- Adds the [50351-nz-slipway-centrelines-topo-150k][50351] dataset to the layer list.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title

[topographic]: https://github.com/linz/basemaps-config/blob/master/config/style/topographic.json
[slipway]: https://wiki.openstreetmap.org/wiki/Tag:leisure%3Dslipway

[1]: https://github.com/linz/basemaps-config/blob/68f82b9b0d933d8ef4cca85ed414b078e0c2ee7e/config/style/topographic.json#L1643
[2]: https://github.com/linz/basemaps-config/blob/68f82b9b0d933d8ef4cca85ed414b078e0c2ee7e/config/style/topographic.json#L1659

[50351]: https://data.linz.govt.nz/layer/50351-nz-slipway-centrelines-topo-150k/