### PR TITLE
feat: add topographic names 3857 BM-1318

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -27,6 +27,7 @@ const Monitor = [
   { id: 106965, name: '106965-nz-1500-tile-index' },
   { id: 106966, name: '106966-nz-12k-tile-index' },
   { id: 105689, name: '105689-nz-addresses-pilot' },
+  { id: 122315, name: '122315-topographic-names-3857' },
   { id: 50063, name: '50063-nz-chatham-island-airport-polygons-topo-150k' },
   { id: 50064, name: '50064-nz-chatham-island-beacon-points-topo-150k' },
   { id: 50065, name: '50065-nz-chatham-island-boatramp-centrelines-topo-150k' },


### PR DESCRIPTION
#### Motivation

Karl has put together a new [Topographic Names 3857 dataset] to drive our topographic labels. This dataset will eventually replace the [NZGB Gazatteer dataset] we currently use for place labels. We want to start caching the new dataset so that we can integrate it into our `topographic-v2` tiles.

#### Modification

- Added the [Topographic Names 3857 dataset] to the list of layers to cache.

#### Checklist

_If not applicable, provide explanation of why._

- [ ] Tests updated
- [ ] Docs updated
- [x] Issue linked in Title

[Topographic Names 3857 dataset]: https://data.linz.govt.nz/layer/122315-topographic-names-3857/
[NZGB Gazatteer dataset]: https://data.linz.govt.nz/layer/51154-nzgb-gazetteer-application-labels-wfs-layer/